### PR TITLE
Fill in itemset mining code

### DIFF
--- a/CodexMLEARN 510 - Lesson 10 - Student Name.ipynb
+++ b/CodexMLEARN 510 - Lesson 10 - Student Name.ipynb
@@ -10,7 +10,7 @@
     "<br>\n",
     "Original version found in MLEARN 510 Canvas. Updated and modified by Ernst Henle\n",
     "<br>\n",
-    "Copyright © 2024 by Ernst Henle \n",
+    "Copyright \u00a9 2024 by Ernst Henle \n",
     "\n",
     "# Learning Objectives:\n",
     "Learning Objectives:\n",
@@ -322,7 +322,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Aggregate Descriptions for each invoice into its own list\n"
+    "# Aggregate Descriptions for each invoice into its own list\n",
+    "invoice_items = UK_Data_of_Interest.groupby('Invoice')['Description'].apply(list)\n"
    ]
   },
   {
@@ -332,7 +333,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create array of transaction lists \n"
+    "# Create array of transaction lists \n",
+    "transactions = invoice_items.tolist()\n",
+    "transactions[:3]  # show first few transactions\n"
    ]
   },
   {
@@ -351,7 +354,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# One hot encode transactions \n"
+    "# One hot encode transactions \n",
+    "te = TransactionEncoder()\n",
+    "te_ary = te.fit(transactions).transform(transactions)\n",
+    "onehot = pd.DataFrame(te_ary, columns=te.columns_)\n",
+    "onehot.head()\n"
    ]
   },
   {
@@ -370,7 +377,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create frequent itemsets\n"
+    "# Create frequent itemsets\n",
+    "freq_itemsets = apriori(onehot, min_support=0.07, use_colnames=True)\n",
+    "freq_itemsets.sort_values('support', ascending=False).head()\n"
    ]
   },
   {
@@ -389,7 +398,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Number of transactions in original input data\n"
+    "# Number of transactions in original input data\n",
+    "print(f'Total transactions: {len(transactions)}')\n",
+    "rules = association_rules(freq_itemsets, metric='confidence', min_threshold=0.7)\n",
+    "rules[['antecedents','consequents','support','confidence','lift']].sort_values('lift', ascending=False).head()\n"
    ]
   },
   {
@@ -407,7 +419,13 @@
    "id": "c1226cb4",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Identify opportunity for promotion based on highest lift\n",
+    "best_rule = rules.sort_values('lift', ascending=False).iloc[0]\n",
+    "print('Best promotion opportunity:')\n",
+    "print(f'If a customer buys {set(best_rule.antecedents)}, recommend {set(best_rule.consequents)}')\n",
+    "print(f'Lift: {best_rule.lift:.2f}')\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- implement code to aggregate items by invoice
- create transaction lists and one-hot encoding
- run apriori and association rule mining
- demonstrate best promotion opportunity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dea113a908331b3d207a7905dd21c