### PR TITLE
Complete content-based recommender exercise

### DIFF
--- a/MLEARN 530-Lesson 8-Student Name.ipynb
+++ b/MLEARN 530-Lesson 8-Student Name.ipynb
@@ -57,7 +57,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Data Exploration 1\n"
+    "#Data Exploration 1\n",
+    "df_movies.info()\n"
    ]
   },
   {
@@ -66,7 +67,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Data Exploration 2\n"
+    "#Data Exploration 2\n",
+    "df_movies['genres'].str.split('|').explode().value_counts()\n"
    ]
   },
   {
@@ -75,7 +77,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#Data Exploration 3\n"
+    "#Data Exploration 3\n",
+    "df_movies['genres'].str.get_dummies('|').sum().sort_values(ascending=False).head(10).plot(kind='bar')\n",
+    "plt.title('Top Genres')\n",
+    "plt.tight_layout()\n"
    ]
   },
   {
@@ -91,9 +96,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#\n",
-    "df_movies = #To Do\n",
-    "df_movies.head()"
+    "# Create genre dummy columns\n",
+    "df_movies = df_movies.join(df_movies['genres'].str.get_dummies('|'))\n",
+    "df_movies.head()\n"
    ]
   },
   {
@@ -109,8 +114,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "movie_chosen = #ToDo\n",
-    "movie_chosen"
+    "movie_chosen = df_movies[df_movies['title']=='Toy Story (1995)'].drop(['movieId','title','genres'], axis=1).squeeze()\n",
+    "movie_chosen.to_frame().T\n"
    ]
   },
   {
@@ -126,8 +131,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_sim = #To Do\n",
-    "df_sim.head()"
+    "df_sim = df_movies[['movieId','title']].copy()\n",
+    "df_sim.head()\n"
    ]
   },
   {
@@ -143,8 +148,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_sim['sim_pearson'] = #To Do\n",
-    "df_sim.head()"
+    "genre_features = df_movies.drop(['movieId','title','genres'], axis=1)\n",
+    "df_sim['sim_pearson'] = genre_features.corrwith(movie_chosen, axis=1)\n",
+    "df_sim.head()\n"
    ]
   },
   {
@@ -164,8 +170,9 @@
    "source": [
     "from sklearn.metrics import jaccard_score\n",
     "\n",
-    "df_sim['sim_jaccard'] = #To Do\n",
-    "df_sim.head()"
+    "genre_features = df_movies.drop(['movieId','title','genres'], axis=1)\n",
+    "df_sim['sim_jaccard'] = genre_features.apply(lambda row: jaccard_score(row, movie_chosen), axis=1)\n",
+    "df_sim.head()\n"
    ]
   },
   {
@@ -183,8 +190,9 @@
    "source": [
     "from sklearn.metrics.pairwise import cosine_similarity\n",
     "\n",
-    "df_sim['sim_cosine'] = #To Do\n",
-    "df_sim.head()"
+    "genre_features = df_movies.drop(['movieId','title','genres'], axis=1)\n",
+    "df_sim['sim_cosine'] = cosine_similarity(genre_features, movie_chosen.values.reshape(1,-1)).ravel()\n",
+    "df_sim.head()\n"
    ]
   },
   {
@@ -220,9 +228,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_sim['ratings_avg'] = #To Do\n",
-    "df_sim['ratings_cnt'] = #To Do\n",
-    "df_sim.head()"
+    "df_sim = df_sim.set_index('movieId')\n",
+    "df_sim['ratings_avg'] = movie_user_mat.mean(axis=1)\n",
+    "df_sim['ratings_cnt'] = movie_user_mat.count(axis=1)\n",
+    "df_sim = df_sim.reset_index()\n",
+    "df_sim.head()\n"
    ]
   },
   {
@@ -238,9 +248,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "less_known = #To Do\n",
-    "high_rating = #To Do\n",
-    "df_sim[less_known & high_rating].sort_values('sim_cosine', ascending = False).head()"
+    "less_known = df_sim['ratings_cnt'] <= df_sim['ratings_cnt'].quantile(0.4)\n",
+    "high_rating = df_sim['ratings_avg'] >= df_sim['ratings_avg'].quantile(0.6)\n",
+    "df_sim[less_known & high_rating].sort_values('sim_cosine', ascending = False).head()\n"
    ]
   },
   {
@@ -256,8 +266,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim_mat = #To Do\n",
-    "print(sim_mat)"
+    "genre_features = df_movies.drop(['movieId','title','genres'], axis=1)\n",
+    "sim_mat = genre_features.T.corr()\n",
+    "print(sim_mat)\n"
    ]
   },
   {
@@ -267,8 +278,9 @@
    "outputs": [],
    "source": [
     "from scipy.spatial.distance import pdist, squareform\n",
-    "sim_mat = #To Do\n",
-    "print(sim_mat)"
+    "genre_features = df_movies.drop(['movieId','title','genres'], axis=1)\n",
+    "sim_mat = 1 - squareform(pdist(genre_features, metric='cosine'))\n",
+    "print(sim_mat)\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- Expanded movie data exploration and encoded genres for similarity calculations.
- Added Pearson, Jaccard, and cosine similarity scores plus rating-based filters for recommendations.
- Generated pairwise similarity matrices via pandas correlation and SciPy distance utilities.

## Testing
- `python - <<'PY' ... PY` *(fails: ModuleNotFoundError: No module named 'pandas')*
- `pip install pandas seaborn matplotlib scikit-learn --quiet` *(fails: Could not find a version that satisfies the requirement pandas; tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b0f55f16e48331878a600cb83daaae